### PR TITLE
Add tests and modify visibility on IsEmpty function

### DIFF
--- a/domain/viacep.go
+++ b/domain/viacep.go
@@ -19,8 +19,8 @@ type ViaCep struct {
 	Siafi      string `json:"siafi"`
 }
 
-// isEmpty retorna true se todas as propriedades da estrutura ViaCep estiverem vazias
-func (v ViaCep) isEmpty() bool {
+// IsEmpty retorna true se todas as propriedades da estrutura ViaCep estiverem vazias
+func (v ViaCep) IsEmpty() bool {
 	return v.Cep == "" && v.Logradouro == "" && v.Bairro == "" && v.Localidade == "" && v.Uf == "" && v.Ibge == "" && v.Gia == "" && v.Ddd == "" && v.Siafi == ""
 }
 
@@ -45,7 +45,7 @@ func BuscaCep(cep string) (*ViaCep, error) {
 	if err != nil {
 		return nil, fmt.Errorf("JSON unmarshalling error: %w", err)
 	}
-	if viaCep.isEmpty() {
+	if viaCep.IsEmpty() {
 		return nil, fmt.Errorf("CEP %s not found", cep)
 	}
 	return &viaCep, nil

--- a/domain/viacep_integration_test.go
+++ b/domain/viacep_integration_test.go
@@ -1,0 +1,25 @@
+package domain_test
+
+import (
+	"http_buscaCep/domain"
+	"testing"
+)
+
+// Chama a função BuscaCep com um valor de "CEP" conhecido.
+// Verifica se houve erro na execução. Se houve algum erro, o teste falha imediatamente.
+// Em seguida, o teste verifica se o retorno de BuscaCep é nil. Se for nil, é um erro inesperado, então o teste falha.
+// Finalmente, o teste verifica se o retorno de BuscaCep não é vazio, o que significa que a função BuscaCep encontrou
+// e retornou os detalhes do CEP. Se o objeto voltar vazio (IsEmpty é true), então o teste falha.
+func TestBuscaCepIntegration(t *testing.T) {
+	cep := "01001001" // Use um CEP existente para o teste
+	c, err := domain.BuscaCep(cep)
+	if err != nil {
+		t.Fatalf("BuscaCep error: %v", err)
+	}
+	if c == nil {
+		t.Fatalf("BuscaCep returned nil ViaCep")
+	}
+	if c.IsEmpty() {
+		t.Errorf("BuscaCep returned empty ViaCep")
+	}
+}

--- a/domain/viacep_test.go
+++ b/domain/viacep_test.go
@@ -1,1 +1,25 @@
-package domain
+package domain_test
+
+import (
+	"http_buscaCep/domain"
+	"testing"
+)
+
+func TestIsEmpty(t *testing.T) {
+
+	t.Run("empty structure", func(t *testing.T) {
+		emptyViaCep := domain.ViaCep{}
+		if emptyViaCep.IsEmpty() != true {
+			t.Logf("Testing with empty structure: %+v", emptyViaCep)
+			t.Errorf("Expected true for an empty ViaCep structure")
+		}
+	})
+
+	t.Run("non-empty structure", func(t *testing.T) {
+		nonEmptyViaCep := domain.ViaCep{Cep: "12345678", Logradouro: "Rua Imaginária"}
+		if nonEmptyViaCep.IsEmpty() != false {
+			t.Logf("Testing with non-empty structure: %+v", nonEmptyViaCep)
+			t.Errorf("Expected false for a non-empty ViaCep structure")
+		}
+	})
+}

--- a/handlers/cep_test.go
+++ b/handlers/cep_test.go
@@ -1,1 +1,56 @@
-package handlers
+package handlers_test
+
+import (
+	"http_buscaCep/handlers"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestBuscaCepHandle faz uma requisição HTTP GET para o servidor HTTP criado pelo teste de integração.
+// Neste caso, o parâmetro cep é informado, então o servidor deve retornar um status 200 OK.
+func TestBuscaCepHandle(t *testing.T) {
+	req, err := http.NewRequest("GET", "/?cep=01001000", nil)
+	if err != nil {
+		t.Fatalf("could not create request: %v", err)
+	}
+	w := httptest.NewRecorder()
+	handlers.BuscaCepHandle(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK; got %v", resp.StatusCode)
+	}
+}
+
+// TestBuscaCepHandle_NoCep faz uma requisição HTTP GET para o servidor HTTP criado pelo teste de integração.
+// Neste caso, o parâmetro cep não é informado, então o servidor deve retornar um erro 400 Bad Request.
+func TestBuscaCepHandle_NoCep(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("could not create request: %v", err)
+	}
+	w := httptest.NewRecorder()
+	handlers.BuscaCepHandle(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status BadRequest; got %v", resp.StatusCode)
+	}
+}
+
+// TestBuscaCepHandle_InvalidCep faz uma requisição HTTP GET para o servidor HTTP criado pelo teste de integração.
+// Neste caso, o parâmetro cep é informado, mas é um CEP inválido, então o servidor deve retornar um erro 500.
+func TestBuscaCepHandle_InvalidLengthCep(t *testing.T) {
+	req, err := http.NewRequest("GET", "/?cep=1234", nil)
+	if err != nil {
+		t.Fatalf("could not create request: %v", err)
+	}
+	w := httptest.NewRecorder()
+	handlers.BuscaCepHandle(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status BadRequest; got %v", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
[EN]
Introduced integration tests for BuscaCep function in the domain for handling known input. Added tests for ViaCep 'IsEmpty' function to handle various inputs. Changed the visibility of the 'isEmpty' function to 'IsEmpty' to access it in the test files. Created 3 test cases for different input scenarios in the http handler. These tests are part of an effort to make the application test-driven, improve code quality and detect bugs early.

[PT-BR]
Adicionar testes e modificar a visibilidade na função IsEmpty

Introduzi testes de integração para a função BuscaCep no domínio para um handle conhecido. Adicionado teste para a função 'IsEmpty' do ViaCep para lidar com várias entradas. Alterada a visibilidade da função 'isEmpty' para 'IsEmpty' para acessá-la nos arquivos de teste. Criei 3 casos de teste para diferentes cenários de entrada no manipulador http. Esses testes são parte de um esforço para tornar o projeto mais testável, melhorar a qualidade do código e detectar bugs precocemente.